### PR TITLE
Fix branch name in version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/EVARepairs/EVARepairs.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/EVARepairs/EVARepairs.version
@@ -1,6 +1,6 @@
 {
     "NAME":"EVARepairs",
-    "URL":"https://raw.githubusercontent.com/Angel-125/EVARepairs/master/ReleaseFolder/GameData/WildBlueIndustries/EVARepairs/EVARepairs.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/EVARepairs/main/ReleaseFolder/GameData/WildBlueIndustries/EVARepairs/EVARepairs.version",
     "DOWNLOAD":"https://github.com/Angel-125/EVARepairs/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125, the netkan validation script says it can't find the remote version file:

![image](https://user-images.githubusercontent.com/1559108/133944386-c1cc124c-48c5-4223-b1d7-f4bfb7a901f9.png)

I think it's because the URL says `master` but the repo uses `main`. The change in this PR should fix that.

Noticed while reviewing KSP-CKAN/NetKAN#8769.